### PR TITLE
Basic changes to work with newer jms/serializer 1.* version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "php": ">=5.3.3",
         "zendframework/zendframework": "2.*",
         "doctrine/doctrine-module": ">=0.5.1",
-        "jms/serializer": "1.*"
+        "jms/serializer": "~1.6"
     },
     "require-dev": {
         "zendframework/zend-developer-tools": "dev-master"

--- a/src/JMSSerializerModule/Module.php
+++ b/src/JMSSerializerModule/Module.php
@@ -184,7 +184,7 @@ class Module implements
                     return $vistor;
                 },
                 'jms_serializer.json_deserialization_visitor' => function (ServiceManager $sm) {
-                    return new JsonDeserializationVisitor($sm->get('jms_serializer.naming_strategy'), $sm->get('jms_serializer.object_constructor'));
+                    return new JsonDeserializationVisitor($sm->get('jms_serializer.naming_strategy'));
                 },
                 'jms_serializer.xml_serialization_visitor' => function(ServiceManager $sm) {
                     return new XmlSerializationVisitor($sm->get('jms_serializer.naming_strategy'));
@@ -194,7 +194,7 @@ class Module implements
                     $options = new Visitors($options['jms_serializer']['visitors']);
 
                     $xmlOptions = $options->getXml();
-                    $visitor = new XmlDeserializationVisitor($sm->get('jms_serializer.naming_strategy'), $sm->get('jms_serializer.object_constructor'));
+                    $visitor = new XmlDeserializationVisitor($sm->get('jms_serializer.naming_strategy'));
                     $visitor->setDoctypeWhitelist($xmlOptions['doctype_whitelist']);
 
                     return $visitor;


### PR DESCRIPTION
JsonDeserializationVisitor and XmlDeserializationVisitor already don't use ObjectConstructorInterface as parameter

still using some deprecated classes (etc GenericSerializationVisitor, ...)